### PR TITLE
Added a `serve` task

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,8 @@ apply plugin: 'jbake'
 This will add a `bake` task to your build, which will search for a standard http://www.jbake.org[JBake] source tree in
 `src/jbake` and generate content into `$buildDir/jbake` (typically `build/jbake`).
 
+It also adds a `serve` task which will start a jetty server on port 8820 to serve the static site.
+
 == Configuration
 === Plugin configuration
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,11 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'org.jbake:jbake-core:2.3.0-SNAPSHOT'
+
+    compile 'javax.servlet:javax.servlet-api:3.0.1'
+    compile('org.eclipse.jetty.aggregate:jetty-all-server:8.1.15.v20140411') {
+        transitive = false
+    }
 }
 
 project.version = '0.1-SNAPSHOT'

--- a/src/main/groovy/me/champeau/gradle/JBakePlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JBakePlugin.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 
 class JBakePlugin implements Plugin<Project> {
     void apply(Project project) {
-        project.task('jbake', type:JBakeTask)
+        project.task('jbake', type: JBakeTask)
+        project.task('serve', type: ServerTask)
     }
 }

--- a/src/main/groovy/me/champeau/gradle/ServeTask.groovy
+++ b/src/main/groovy/me/champeau/gradle/ServeTask.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.gradle
+
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.ContextHandler
+import org.eclipse.jetty.server.handler.DefaultHandler
+import org.eclipse.jetty.server.handler.HandlerList
+import org.eclipse.jetty.server.handler.ResourceHandler
+import org.eclipse.jetty.server.nio.SelectChannelConnector
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.TaskAction
+
+class ServerTask extends AbstractTask {
+    Long port = 8820
+
+    @TaskAction
+    void serve() {
+        def server = new Server()
+        def connector = new SelectChannelConnector()
+        connector.port = port
+        server.addConnector(connector)
+
+        def resource_handler = new ResourceHandler()
+        resource_handler.directoriesListed = true
+        resource_handler.welcomeFiles = ['index.html']
+
+        resource_handler.resourceBase = project.tasks.jbake.output
+
+        def context = new ContextHandler()
+        context.handler = resource_handler
+        context.contextPath = '/'
+
+        def handlers = new HandlerList()
+        handlers.handlers = [context, new DefaultHandler()]
+        server.handler = handlers
+
+        println("Serving out contents on http://localhost:${connector.port}/");
+        println("(To stop server hit CTRL-C)");
+
+        server.start()
+        server.join()
+    }
+
+}


### PR DESCRIPTION
Serve will start a jetty server on port 8820 to
serve the static content for testing purposes.

This code is based on Cedric's serve.groovy 
in his blog. 