### PR TITLE
jbakeClean task and and jbake renamed to jbakeBuild

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,8 +29,10 @@ buildscript {
 apply plugin: 'me.champeau.jbake'
 ----
 
-This will add a `jbake` task to your build, which will search for a standard http://www.jbake.org[JBake] source tree in
+This will add a `jbakeBuild` task to your build, which will search for a standard http://www.jbake.org[JBake] source tree in
 `src/jbake` and generate content into `$buildDir/jbake` (typically `build/jbake`).
+
+There is also a `jbakeClean` task to delete the build directory content.
 
 == Configuration
 === Plugin configuration

--- a/src/main/groovy/me/champeau/gradle/JBakePlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JBakePlugin.groovy
@@ -15,6 +15,8 @@
  */
 package me.champeau.gradle
 
+import me.champeau.gradle.tasks.JBakeBuild
+import me.champeau.gradle.tasks.JBakeClean
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -39,7 +41,7 @@ class JBakePlugin implements Plugin<Project> {
 
         addDependenciesAfterEvaluate()
 
-        project.task('jbake', type: JBakeTask, group: 'Documentation', description: 'Bake a jbake project'){
+        project.task('jbakeBuild', type: JBakeBuild, group: 'Documentation', description: 'Bake a jbake project'){
 
             classpath = configuration
             conventionMapping.input = { project.file("$project.projectDir/$project.jbake.srcDirName") }
@@ -47,6 +49,8 @@ class JBakePlugin implements Plugin<Project> {
             conventionMapping.clearCache = { project.jbake.clearCache }
             conventionMapping.configuration = { project.jbake.configuration }
         }
+
+        project.task('jbakeClean', type: JBakeClean, group: 'Documentation', description: 'Delete the build directory')
 
     }
 

--- a/src/main/groovy/me/champeau/gradle/tasks/JBakeBuild.groovy
+++ b/src/main/groovy/me/champeau/gradle/tasks/JBakeBuild.groovy
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.champeau.gradle
+package me.champeau.gradle.tasks
 
+import me.champeau.gradle.JBakeProxy
+import me.champeau.gradle.JBakeProxyImpl
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.Input
@@ -24,7 +26,7 @@ import org.gradle.api.tasks.TaskAction
 
 import java.lang.reflect.Constructor
 
-class JBakeTask extends DefaultTask {
+class JBakeBuild extends DefaultTask {
     @InputDirectory File input
     @OutputDirectory File output
     @Input Map<String, Object> configuration = [:]

--- a/src/main/groovy/me/champeau/gradle/tasks/JBakeClean.groovy
+++ b/src/main/groovy/me/champeau/gradle/tasks/JBakeClean.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class JBakeClean extends DefaultTask {
+
+    @TaskAction
+    void clean() {
+        def result = project.buildDir.deleteDir()
+    }
+
+}

--- a/src/test/groovy/me/champeau/gradle/JBakePluginSpec.groovy
+++ b/src/test/groovy/me/champeau/gradle/JBakePluginSpec.groovy
@@ -1,5 +1,7 @@
 package me.champeau.gradle
 
+import me.champeau.gradle.tasks.JBakeBuild
+import me.champeau.gradle.tasks.JBakeClean
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -18,11 +20,16 @@ class JBakePluginSpec extends Specification {
         project.apply plugin: PLUGIN_ID
     }
 
-
-    def "should add a JBakeTask"(){
+    def "should add a JBakeClean"(){
 
         expect:
-        project.tasks.jbake instanceof JBakeTask
+        project.tasks.jbakeClean instanceof JBakeClean
+    }
+
+    def "should add a JBakeBuild"(){
+
+        expect:
+        project.tasks.jbakeBuild instanceof JBakeBuild
     }
 
     def "should add jbake configuration"(){
@@ -114,7 +121,7 @@ class JBakePluginSpec extends Specification {
         project.jbake.srcDirName = srcDirName
 
         then:
-        project.tasks.jbake.input == expectedFile
+        project.tasks.jbakeBuild.input == expectedFile
     }
 
     def "output dir should be configured by extension"(){
@@ -126,7 +133,7 @@ class JBakePluginSpec extends Specification {
         project.jbake.destDirName = destDirName
 
         then:
-        project.tasks.jbake.output == expectedFile
+        project.tasks.jbakeBuild.output == expectedFile
     }
 
     def "clearcache should be configured by extension"(){
@@ -137,7 +144,7 @@ class JBakePluginSpec extends Specification {
         project.jbake.clearCache = clearCache
 
         then:
-        project.tasks.jbake.clearCache == clearCache
+        project.tasks.jbakeBuild.clearCache == clearCache
     }
 
     def "should be configurable by extension"(){
@@ -149,7 +156,7 @@ class JBakePluginSpec extends Specification {
         project.jbake.configuration = configuration
 
         then:
-        project.tasks.jbake.configuration['render.tags'] == false
+        project.tasks.jbakeBuild.configuration['render.tags'] == false
     }
 
 }


### PR DESCRIPTION
I've implemented a very basic clean task as requested in #11. I named jbakeClean and renamed jbake to jbakeBuild, if another naming is preferred, just let me know and I will update the PR. My idea is to add jbakeInit and jbakeServer tasks in the same way with some integration tests.