### PR TITLE
Fixing issue #42

### DIFF
--- a/src/main/groovy/org/jbake/gradle/JBakeServeTask.groovy
+++ b/src/main/groovy/org/jbake/gradle/JBakeServeTask.groovy
@@ -46,7 +46,7 @@ class JBakeServeTask extends DefaultTask {
         createJettyServer()
         jettyServer.prepare()
         println("Starting server. Browse to http://localhost:$port")
-        jettyServer.run(input.absolutePath, port)
+        jettyServer.run(getInput().absolutePath, port)
     }
 
     private JettyServerProxy createJettyServer() {


### PR DESCRIPTION
This small change resolves a `NullPointerException` that occurs when the `JBakeServeTask` is trying to grab the input directory from the Gradle convention mapping. This is because it is trying to directly access the `input` field, rather than calling the accessor method. This switch allows the task to get the correctly configured value.