### PR TITLE
Use the worker API for Gradle 5.6 and above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     compileOnly("org.jbake:jbake-core:$jbakeVersion") {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
+    compileOnly 'commons-configuration:commons-configuration:1.10'
     testImplementation("org.spockframework:spock-core:$spockVersion") {
         exclude group: 'org.codehaus.groovy'
     }

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkAction.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkAction.groovy
@@ -23,9 +23,6 @@ import org.gradle.api.logging.Logging
 import org.gradle.workers.WorkAction
 import org.jbake.app.Oven
 
-/**
- * @author Daniel Lacasse (@lacasseio)
- */
 abstract class JBakeWorkAction implements WorkAction<JBakeWorkActionParameters> {
     private static final LOGGER = Logging.getLogger(JBakeWorkAction)
     private Oven jbake

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkAction.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkAction.groovy
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbake.gradle.impl
+
+import org.apache.commons.configuration.CompositeConfiguration
+import org.apache.commons.configuration.MapConfiguration
+import org.gradle.api.logging.Logging
+import org.gradle.workers.WorkAction
+import org.jbake.app.Oven
+
+abstract class JBakeWorkAction implements WorkAction<JBakeWorkActionParameters> {
+    private static final LOGGER = Logging.getLogger(JBakeWorkAction)
+    private Oven jbake
+
+    @Override
+    void execute() {
+        jbake = new Oven(parameters.input.get().asFile, parameters.output.get().asFile, parameters.clearCache.get())
+        jbake.setupPaths()
+        mergeConfiguration()
+        jbake.bake()
+        List<String> errors = jbake.getErrors()
+        if (errors) {
+            errors.each { LOGGER.error(it) }
+            throw new IllegalStateException(errors.join('\n'))
+        }
+    }
+
+    private void mergeConfiguration() {
+        def config = new CompositeConfiguration([createMapConfiguration(), jbake.getConfig()])
+        jbake.setConfig(config)
+    }
+
+    private MapConfiguration createMapConfiguration() {
+        return new MapConfiguration(parameters.configuration.get())
+    }
+}

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkAction.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkAction.groovy
@@ -23,6 +23,9 @@ import org.gradle.api.logging.Logging
 import org.gradle.workers.WorkAction
 import org.jbake.app.Oven
 
+/**
+ * @author Daniel Lacasse (@lacasseio)
+ */
 abstract class JBakeWorkAction implements WorkAction<JBakeWorkActionParameters> {
     private static final LOGGER = Logging.getLogger(JBakeWorkAction)
     private Oven jbake

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
@@ -28,5 +28,5 @@ interface JBakeWorkActionParameters extends WorkParameters {
 
     Property<Boolean> getClearCache()
 
-    MapProperty<String, Object> getConfiguration();
+    MapProperty<String, Object> getConfiguration()
 }

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
@@ -22,9 +22,6 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property;
 import org.gradle.workers.WorkParameters;
 
-/**
- * @author Daniel Lacasse (@lacasseio)
- */
 interface JBakeWorkActionParameters extends WorkParameters {
     RegularFileProperty getInput()
     RegularFileProperty getOutput()

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
@@ -22,6 +22,9 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property;
 import org.gradle.workers.WorkParameters;
 
+/**
+ * @author Daniel Lacasse (@lacasseio)
+ */
 interface JBakeWorkActionParameters extends WorkParameters {
     RegularFileProperty getInput()
     RegularFileProperty getOutput()

--- a/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
+++ b/src/main/groovy/org/jbake/gradle/impl/JBakeWorkActionParameters.groovy
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbake.gradle.impl
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property;
+import org.gradle.workers.WorkParameters;
+
+interface JBakeWorkActionParameters extends WorkParameters {
+    RegularFileProperty getInput()
+    RegularFileProperty getOutput()
+
+    Property<Boolean> getClearCache()
+
+    MapProperty<String, Object> getConfiguration();
+}


### PR DESCRIPTION
It fixes https://github.com/jbake-org/jbake-gradle-plugin/issues/56 and https://github.com/jbake-org/jbake-gradle-plugin/issues/53 on Gradle 5.6 and above. For Gradle 5.5 and lower, nothing has changed. I created a fix for Gradle 5.5 and lower but it presented a regression: https://github.com/lacasseio/jbake-gradle-plugin/commit/37044a4fff25f595029b3e5ec5829caede29dcca.

Before:
<img width="1096" alt="Screen Shot 2020-06-27 at 9 54 47 AM" src="https://user-images.githubusercontent.com/22181740/85924446-6212ec80-b860-11ea-91b6-d32dcc198bbe.png">

After:
<img width="1091" alt="Screen Shot 2020-06-27 at 9 54 56 AM" src="https://user-images.githubusercontent.com/22181740/85924452-6939fa80-b860-11ea-98aa-8d5a13c948d0.png">
