### PR TITLE
point users to the matching version README on the plugins website url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ config {
         specification { enabled = false }
 
         links {
-            website      = "https://github.com/jbake-org/${project.rootProject.name}"
+            website      = "https://github.com/jbake-org/${project.rootProject.name}/tree/v${project.rootProject.version}"
             issueTracker = "https://github.com/jbake-org/${project.rootProject.name}/issues"
             scm          = "https://github.com/jbake-org/${project.rootProject.name}.git"
         }


### PR DESCRIPTION
Currently the website url on the [plugin page](https://plugins.gradle.org/plugin/org.jbake.site) points to the latest state of the repository main branch.

It can be confusing looking at the README which is not released yet.

Maybe it helps if the users are pointed directly to the latest release like https://github.com/jbake-org/jbake-gradle-plugin/tree/v5.4.0,
derived from the current plugin version.