### PR TITLE
Upgrade to JBake 2.7.0-rc.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,14 @@ repositories {
     mavenCentral()
 }
 
+configurations.all {
+    resolutionStrategy {
+        force "com.github.jnr:jnr-posix:3.1.15"
+        force "com.github.jnr:jnr-constants:0.10.3"
+        force "com.github.jnr:jffi:1.3.9"
+    }
+}
+
 dependencies {
     compileOnly gradleApi()
     api "com.github.zafarkhaja:java-semver:$semverVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,8 @@ targetCompatibility       = 1.8
 
 kordampPluginVersion      = 0.45.0
 kordampBuildVersion       = 2.4.0
-commonsIoVersion          = 2.8.0
-jbakeVersion              = 2.6.7
+commonsIoVersion          = 2.11.0
+jbakeVersion              = 2.7.0-rc.6
 semverVersion             = 0.9.0
 spockVersion              = 2.0-groovy-2.5
-jettyVersion              = 9.4.36.v20210114
+jettyVersion              = 9.4.44.v20210927

--- a/src/test/groovy/org/jbake/gradle/JbakeIntegrationSpec.groovy
+++ b/src/test/groovy/org/jbake/gradle/JbakeIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class JbakeIntegrationSpec extends PluginIntegrationSpec {
     String latestGradleVersion = '7.0.2'
 
     @Shared
-    String latestJbakeVersion = '2.6.7'
+    String latestJbakeVersion = '2.7.0-rc.6'
 
     @Unroll
     def 'Setup and bake with gradle #version'() {


### PR DESCRIPTION
This builds on **macOS** with Apple Silicon.

Also updated related dependencies

Notes:

1. Hard-coded resolutionStrategy versions in build.gradle
2. Hard-coded rc.6 release of JBake 2.7.0